### PR TITLE
Chore: Compatibility for exported typo from 1.12+ generator

### DIFF
--- a/pkg/builders/api_version_builder.go
+++ b/pkg/builders/api_version_builder.go
@@ -29,6 +29,10 @@ type VersionedApiBuilder struct {
 	Kinds         []*versionedResourceBuilder
 	GroupVersion  schema.GroupVersion
 	SchemeBuilder runtime.SchemeBuilder
+
+	// Deprecated: Only for compiliation backward-compatibility w/ 1.12+ version generators
+	// removing in the future
+	SchemaBuilder runtime.SchemeBuilder
 }
 
 func NewApiVersion(group, version string) *VersionedApiBuilder {


### PR DESCRIPTION
in 1.12+ generator, we have typo from the field `ApiVersion#SchemaBuilder`, and we renamed it to `SchemeBuilder` in 1.15+ to align w/ k/k upstream. we preserve the old name to avoid breaking compatibility between (1.12+ generator) and (1.15+ vendor)