### PR TITLE
Fix go vet error 'composite literal uses unkeyed fields' in generated code

### DIFF
--- a/cmd/apiregister-gen/generators/versioned_generator.go
+++ b/cmd/apiregister-gen/generators/versioned_generator.go
@@ -96,7 +96,7 @@ var (
 			{{ $api.Group }}.Internal{{ $api.Kind }}Status,
 			func() runtime.Object { return &{{ $api.Kind }}{} },     // Register versioned resource
 			func() runtime.Object { return &{{ $api.Kind }}List{} }, // Register versioned resource list
-			&{{ $api.Group }}.{{ $api.StatusStrategy }}{builders.StatusStorageStrategySingleton},
+			&{{ $api.Group }}.{{ $api.StatusStrategy }}{DefaultStatusStorageStrategy: builders.StatusStorageStrategySingleton},
 		),{{ end -}}
 
 		{{ range $subresource := $api.Subresources -}}
@@ -105,7 +105,7 @@ var (
 			func() runtime.Object { return &{{ $subresource.Request }}{} }, // Register versioned resource
 			nil,
             {{ if $subresource.REST }}{{ $api.Group }}.New{{ $subresource.REST }}{{ else -}}
-			func(generic.RESTOptionsGetter) rest.Storage { return &{{ $api.Group }}.{{ $subresource.Kind }}REST{ {{$api.Group}}.New{{$api.Kind}}Registry({{$api.Group}}.{{$api.Group|public}}{{$api.Kind}}Storage) } },
+			func(generic.RESTOptionsGetter) rest.Storage { return &{{ $api.Group }}.{{ $subresource.Kind }}REST{Registry: {{$api.Group}}.New{{$api.Kind}}Registry({{$api.Group}}.{{$api.Group|public}}{{$api.Kind}}Storage) } },
 			{{ end -}}
 		),
 		{{ end -}}

--- a/cmd/apiserver-boot/boot/create/resource.go
+++ b/cmd/apiserver-boot/boot/create/resource.go
@@ -471,6 +471,7 @@ var admissionControllerTemplate = `
 package {{ lower .Kind }}admission
 
 import (
+	"context"
 	aggregatedadmission "{{.Repo}}/plugin/admission"
 	aggregatedinformerfactory "{{.Repo}}/pkg/client/informers_generated/externalversions"
 	aggregatedclientset "{{.Repo}}/pkg/client/clientset_generated/clientset"
@@ -502,11 +503,11 @@ func (p *{{ lower .Kind }}Plugin) ValidateInitialization() error {
 	return nil
 }
 
-func (p *{{ lower .Kind }}Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterface) error {
+func (p *{{ lower .Kind }}Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	return nil
 }
 
-func (p *{{ lower .Kind }}Plugin) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterface) error {
+func (p *{{ lower .Kind }}Plugin) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	return nil
 }
 

--- a/example/basic/Makefile
+++ b/example/basic/Makefile
@@ -16,9 +16,12 @@
 
 all: test
 
-test: build
+test: build check
 	go test ./pkg/...
 	bash -c "find pkg/apis/ -name apiserver.local.config | xargs rm -rf"
+
+check:
+	go vet $$(go list ./... | grep -vE '(clientset|listers|informers)_generated')
 
 build: cmds
 	bin/apiserver-boot build executables --vendor-dir ../../

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,9 +18,12 @@ all: test
 
 NON_INTERACTIVE_FLAG=--skip-resource=false --skip-controller=false --skip-admission-controller=false
 
-test: build
+test: build check
 	go test ./pkg/...
 	bash -c "find pkg/apis/ -name apiserver.local.config | xargs rm -rf"
+
+check: build
+	go vet $$(go list ./... | grep -vE '(clientset|listers|informers)_generated')
 
 skeleton: cmds
 	apiserver-boot init repo --domain sample.kubernetes.io


### PR DESCRIPTION
close #435 

Also, `go vet` check is added in the test.

Signed-off-by: Aylei <rayingecho@gmail.com>