### PR TITLE
Enable admission installation by default on repo-init

### DIFF
--- a/cmd/apiserver-boot/boot/init_repo/repo.go
+++ b/cmd/apiserver-boot/boot/init_repo/repo.go
@@ -151,6 +151,7 @@ import (
 
 	"{{.Repo}}/pkg/apis"
 	"{{.Repo}}/pkg/openapi"
+	_ "{{.Repo}}/plugin/admission/install"
 )
 
 func main() {


### PR DESCRIPTION
and this will make the integration test cover the admission portion