### PR TITLE
apiserver-gen: add comment for blank imports

### DIFF
--- a/cmd/apiregister-gen/generators/apis_generator.go
+++ b/cmd/apiregister-gen/generators/apis_generator.go
@@ -52,7 +52,7 @@ func (d *apiGenerator) Imports(c *generator.Context) []string {
 	}
 	for _, group := range d.apis.Groups {
 		imports = append(imports, fmt.Sprintf(
-			"_ \"%s/install\"", group.Pkg.Path))
+			"_ \"%s/install\" // Install the %s group", group.Pkg.Path, group.Group))
 	}
 
 	return imports


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

Add comment for blank imports generated by `apiserver-gen`, e.g.

```go
import (
	"k8s.io/apimachinery/pkg/runtime"
	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/innsmouth"
	_ "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/innsmouth/install" // Install the innsmouth group
	innsmouthv1 "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/innsmouth/v1"
	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/kingsport"
	_ "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/kingsport/install" // Install the kingsport group
	kingsportv1 "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/kingsport/v1"
	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/miskatonic"
	_ "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/miskatonic/install" // Install the miskatonic group
	miskatonicv1beta1 "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/miskatonic/v1beta1"
	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/olympus"
	_ "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/olympus/install" // Install the olympus group
	olympusv1beta1 "sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis/olympus/v1beta1"
	"sigs.k8s.io/apiserver-builder-alpha/pkg/builders"
)
```

close #442 