### PR TITLE
fix(apiserver-gen): explicit decalre 'k8s.io/apimachinery/pkg/runtime' for apis_generator to avoid goimports bug

### DIFF
--- a/cmd/apiregister-gen/generators/apis_generator.go
+++ b/cmd/apiregister-gen/generators/apis_generator.go
@@ -42,6 +42,7 @@ func CreateApisGenerator(apis *APIs, filename string) generator.Generator {
 func (d *apiGenerator) Imports(c *generator.Context) []string {
 	imports := []string{
 		"sigs.k8s.io/apiserver-builder-alpha/pkg/builders",
+		"k8s.io/apimachinery/pkg/runtime",
 	}
 	for _, group := range d.apis.Groups {
 		imports = append(imports, group.PkgPath)


### PR DESCRIPTION
`cmd/apiregister-gen` use `k8s.io/gengo`, which will use `golang.org/x/tools/imports` for post-processing after code generation. Since apis_generator.go haven't explicitly declared `k8s.io/apimachinery/pkg/runtime` but it use `runtime` in `APIsTemplate`, `gengo` won't find import path for `runtime` and this will be done by `golang.org/x/tools/imports`. However, `goimports` cannot parse soft link. It means, if all go files in `k8s.io/apimachinery/pkg/runtime` are symlink files and point to another directory not in GOPATH, `goimports` cannot find import package for `runtime`.

An example for this is to use bazel for code generation by using `apiregister-gen`. In [k8s.io/repo-infra](https://github.com/kubernetes/repo-infra/blob/v0.0.1-alpha.1/defs/go.bzl#L104), it defines a `go_genrule` for generating a GOPATH dir structure in which go files are all symlinks. So this may make `goimports` cannot find correct import package for `runtime`.