### PR TITLE
fix: remove replace of glog to klog in go.mod

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -20,5 +20,3 @@ require (
 	sigs.k8s.io/controller-tools v0.1.10 // indirect
 	sigs.k8s.io/kubebuilder v0.0.0-20190320190143-2621a6fdb324
 )
-
-replace github.com/golang/glog => k8s.io/klog v0.3.1

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -185,6 +185,7 @@ github.com/gobuffalo/x v0.0.0-20181007152206-913e47c59ca7/go.mod h1:9rDPXaB3kXdK
 github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 h1:WSBJMqJbLxsn+bTCPyPYZfqHdJmc8MK4wrBjMft6BAM=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
This 'replace' line make go build not work in go modules mod. It will cause an error below:

```
go: k8s.io/klog@v0.3.1 used for two different module paths (github.com/golang/glog and k8s.io/klog)
```

Since `github.com/golang/glog` is only referred from vendor, using go modules will discard `vendor` so that this `replace` is unnecessary.

So removing this line can avoid this error and make go modules work while building `apiserver-boot`, `apiregister-gen` and `apiserver-builder-release`