### PR TITLE
build: add stamp variables injection for defining apiserver-builder version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+build --stamp
+run --stamp
+
+# populate env used for stamping builds etc
+build --workspace_status_command=./scripts/print-workspace-status.sh
+run --workspace_status_command=./scripts/print-workspace-status.sh

--- a/cmd/apiserver-boot/boot/version/BUILD.bazel
+++ b/cmd/apiserver-boot/boot/version/BUILD.bazel
@@ -9,4 +9,10 @@ go_library(
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_klog//:go_default_library",
     ],
+    x_defs = {
+        "apiserverBuilderVersion": "{APISERVER_BUILDER_VERSION}",
+        "kubernetesVendorVersion": "{K8S_VENDOR}",
+        "gitCommit": "{GIT_COMMIT}",
+        "buildDate": "{BUILD_DATE}",
+    },
 )

--- a/cmd/apiserver-boot/boot/version/version.go
+++ b/cmd/apiserver-boot/boot/version/version.go
@@ -18,6 +18,7 @@ package version
 
 import (
 	"k8s.io/klog"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -25,8 +26,8 @@ import (
 var (
 	apiserverBuilderVersion = "unknown"
 	kubernetesVendorVersion = "unknown"
-	goos                    = "unknown"
-	goarch                  = "unknown"
+	goos                    = runtime.GOOS
+	goarch                  = runtime.GOARCH
 	gitCommit               = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
 
 	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/scripts/print-workspace-status.sh
+++ b/scripts/print-workspace-status.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+apiserver_builder_version="v1.16.alpha.0"
+k8s_vendor="v1.16.0"
+git_commit="$(git rev-parse HEAD)"
+build_date="$(date +%Y-%m-%d-%H:%M:%S)"
+
+cat <<EOF
+APISERVER_BUILDER_VERSION ${apiserver_builder_version}
+GIT_COMMIT ${git_commit}
+BUILD_DATE ${build_date}
+K8S_VENDOR ${k8s_vendor}
+EOF


### PR DESCRIPTION
`apiserver-builder-release` define `apiserverBuilderVersion`, `kubernetesVendorVersion`, `gitCommit`, `buildDate`, `goos`, `goarch` for `apiserver-boot`. But these variables can be defined elegantly by [rules_go's stamp variables](https://github.com/bazelbuild/rules_go/blob/master/go/core.rst#defines-and-stamping).

Also I think the default value of `goos`, `goarch` should be `runtime.GOOS` and `runtime.GOARCH`.

Using the strategy of stamp variables of bazel, after executing bazel build for `apiserver-boot`, variables in `scripts/print-workspace-status.sh` can be injected into `cmd/apiserver-boot/boot/version/version.go`.