### PR TITLE
feat(test): move logic from Start to New for exporting apiserver cmd and options

### DIFF
--- a/cmd/apiserver-boot/boot/create/resource.go
+++ b/cmd/apiserver-boot/boot/create/resource.go
@@ -373,8 +373,8 @@ func Test{{title .Version}}(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/example/basic/pkg/apis/innsmouth/v1/v1_suite_test.go
+++ b/example/basic/pkg/apis/innsmouth/v1/v1_suite_test.go
@@ -36,8 +36,8 @@ func TestOpenapi(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/example/basic/pkg/apis/kingsport/v1/v1_suite_test.go
+++ b/example/basic/pkg/apis/kingsport/v1/v1_suite_test.go
@@ -19,10 +19,10 @@ package v1_test
 import (
 	"testing"
 
-	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 
 	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis"
 	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/client/clientset_generated/clientset"
@@ -39,8 +39,8 @@ func TestV1(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/example/basic/pkg/apis/miskatonic/v1beta1/v1beta1_suite_test.go
+++ b/example/basic/pkg/apis/miskatonic/v1beta1/v1beta1_suite_test.go
@@ -36,8 +36,8 @@ func TestOpenapi(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/example/basic/pkg/apis/olympus/v1beta1/v1beta1_suite_test.go
+++ b/example/basic/pkg/apis/olympus/v1beta1/v1beta1_suite_test.go
@@ -19,10 +19,10 @@ package v1beta1_test
 import (
 	"testing"
 
-	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 
 	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/apis"
 	"sigs.k8s.io/apiserver-builder-alpha/example/basic/pkg/client/clientset_generated/clientset"
@@ -39,8 +39,8 @@ func TestV1beta1(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/example/kine/pkg/apis/sqlite/v1alpha1/v1alpha1_suite_test.go
+++ b/example/kine/pkg/apis/sqlite/v1alpha1/v1alpha1_suite_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2019 The Kubernetes Authors.
 
@@ -15,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-
 package v1alpha1_test
 
 import (
@@ -24,8 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 
 	"sigs.k8s.io/apiserver-builder-alpha/example/kine/pkg/apis"
 	"sigs.k8s.io/apiserver-builder-alpha/example/kine/pkg/client/clientset_generated/clientset"
@@ -42,8 +39,8 @@ func TestV1alpha1(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/example/podexec/pkg/apis/podexec/v1/v1_suite_test.go
+++ b/example/podexec/pkg/apis/podexec/v1/v1_suite_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2019 The Kubernetes Authors.
 
@@ -15,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-
 package v1_test
 
 import (
@@ -24,8 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 
 	"sigs.k8s.io/apiserver-builder-alpha/example/podexec/pkg/apis"
 	"sigs.k8s.io/apiserver-builder-alpha/example/podexec/pkg/client/clientset_generated/clientset"
@@ -42,8 +39,8 @@ func TestV1(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/example/podlogs/pkg/apis/podlogs/v1/v1_suite_test.go
+++ b/example/podlogs/pkg/apis/podlogs/v1/v1_suite_test.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2019 The Kubernetes Authors.
 
@@ -15,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-
 package v1_test
 
 import (
@@ -24,8 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/apiserver-builder-alpha/pkg/test"
 
 	"sigs.k8s.io/apiserver-builder-alpha/example/podlogs/pkg/apis"
 	"sigs.k8s.io/apiserver-builder-alpha/example/podlogs/pkg/client/clientset_generated/clientset"
@@ -42,8 +39,8 @@ func TestV1(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	testenv = test.NewTestEnvironment(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	config = testenv.Start()
 	cs = clientset.NewForConfigOrDie(config)
 })
 

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -56,9 +56,10 @@ type TestEnvironment struct {
 
 func NewTestEnvironment(apis []*builders.APIGroupBuilder, openapidefs openapi.GetOpenAPIDefinitions) *TestEnvironment {
 	te := &TestEnvironment{
-		EtcdPath:   "/registry/test.kubernetes.io",
-		StopServer: make(chan struct{}),
-		etcdready:  make(chan string),
+		EtcdPath:       "/registry/test.kubernetes.io",
+		StopServer:     make(chan struct{}),
+		etcdready:      make(chan string),
+		apiserverready: make(chan *rest.Config),
 	}
 
 	te.EtcdClientPort = te.getPort()


### PR DESCRIPTION
Sometimes, we will add `FlagConfigFuncs` in customize apiserver's `StartOptions`. This will be blocked while using `pkg/test` package since there's no `StartOptions` being registered in the `TestEnvironment`. Also, if we want to control flags of apiserver, we need to have access permission of the test apiserver's cobra command.
Moreover, lots of operations in the `Start` function of `TestEnvironment` seem to do a initialization. I think they should be moved into `NewTestEnvironment` so that we can export the `ApiserverCobraCmd` and `ApiserverOptions` to user to customize their test logic.