### PR TITLE
added support for windows users to use the TestEnvironment

### DIFF
--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -151,6 +152,7 @@ func (te *TestEnvironment) startEtcd() {
 	if err != nil {
 		panic(err)
 	}
+	defer os.Remove(dirname)
 
 	clientAddr := fmt.Sprintf("http://localhost:%d", te.EtcdClientPort)
 	peerAddr := fmt.Sprintf("http://localhost:%d", te.EtcdPeerPort)


### PR DESCRIPTION
Started etcd requires a `/tmp` directory which doesn't exist on Windows machines. If a windows machine attempts to create a `TestEnvironment`, the etcd data will be saved to the relative path `./tmp` and it will be removed when the test completes.