### PR TITLE
Test env windows support

### DIFF
--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -153,7 +153,8 @@ func (te *TestEnvironment) startEtcd() {
 	var tempDir string
 	switch runtime.GOOS {
 	case "windows":
-		tempDir = "./tmp"
+		// ioutil requires the dir to exist, we'll create our temp dir where we're at
+		tempDir = "./"
 	default:
 		tempDir = "/tmp"
 	}


### PR DESCRIPTION
Started etcd requires a /tmp directory which doesn't exist on Windows machines. If a windows machine attempts to create a TestEnvironment, the etcd data will be saved to the relative path ./ and it will be removed when the test completes.