### PR TITLE
Remove directxman12 from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,7 @@
 
 reviewers:
   - pwittrock
-  - directxman12
   - yue9944882
 approvers:
   - pwittrock
-  - directxman12
   - yue9944882


### PR DESCRIPTION
As per
https://groups.google.com/g/kubebuilder/c/-5hOFa_adr4/m/Sp_Zb755AwAJ,
directxman12 is stepping down.