### PR TITLE
fix: identify etcd service by namespace.

### DIFF
--- a/pkg/boot/build/build_resource_config.go
+++ b/pkg/boot/build/build_resource_config.go
@@ -344,7 +344,7 @@ spec:
         command:
         - "./apiserver"
         args:
-        - "--etcd-servers=http://etcd-svc:2379"
+        - "--etcd-servers=http://etcd-svc.{{.Namespace}}.svc:2379"
         - "--tls-cert-file=/apiserver.local.config/certificates/tls.crt"
         - "--tls-private-key-file=/apiserver.local.config/certificates/tls.key"
         - "--audit-log-path=-"


### PR DESCRIPTION
When I tested, I found that etcd's service addressing is not very rigorous. If users do not read the source code, it may not be well understood.