### PR TITLE
 windows gitbash problem. GOCACHE is not defined and %LocalAppData% is not defined

### DIFF
--- a/pkg/boot/build/build_executables.go
+++ b/pkg/boot/build/build_executables.go
@@ -198,8 +198,17 @@ func GoBuild(cmd *cobra.Command, args []string) {
 
 	if buildController() {
 		// Build the controller manager
+		gocache := os.Getenv("GOCACHE")
+		localAppData := os.Getenv("%LocalAppData%")
 		path := filepath.Join("cmd", "manager", "main.go")
 		c := exec.Command("go", "build", "-o", filepath.Join(outputdir, "controller-manager"), path)
+		// add GOCACHE and LocalAppData environment variable
+		if len(localAppData) > 0 {
+			c.Env = append(c.Env, fmt.Sprintf("GOCACHE=%s", gocache))
+		}
+		if len(localAppData) > 0 {
+			c.Env = append(c.Env, fmt.Sprintf("LocalAppData=%s", localAppData))
+		}
 		if len(os.Getenv("CGO_ENABLED")) == 0 {
 			c.Env = append(os.Environ(), "CGO_ENABLED=0")
 		}


### PR DESCRIPTION
apiserver-boot 在windows环境下的gitbash执行   apiserver-boot build container --image k8sCase/kr-apiserver:0.0.1报错 GOCACHE is not defined and %LocalAppData% is not defined